### PR TITLE
[INVE-26823] Improve errors on unhandled long response strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "description": "The official low-level Elasticsearch client for Node.js and the browser.",
   "main": "src/elasticsearch.js",
   "homepage": "https://www.elastic.co/guide/en/elasticsearch/client/elasticsearch-js/16.x/index.html",
-  "version": "16.7.3",
+  "version": "16.7.3-sirensolutions-1",
   "keywords": [
     "elasticsearch",
     "mapping",

--- a/src/lib/connectors/http.js
+++ b/src/lib/connectors/http.js
@@ -196,8 +196,8 @@ HttpConnector.prototype.request = function(params, cb) {
         response += d;
       } catch (error) {
         // When stringified response is too big, we will catch this moment
-        // and throw an error to make sure server is NOT crashed
-        this.emit('end', error);
+        // and destroy it to make sure server is NOT crashed
+        this.destroy(error);
       }
     });
 

--- a/src/lib/connectors/http.js
+++ b/src/lib/connectors/http.js
@@ -192,7 +192,13 @@ HttpConnector.prototype.request = function(params, cb) {
 
     incoming.setEncoding('utf8');
     incoming.on('data', function(d) {
-      response += d;
+      try {  
+        response += d;
+      } catch (error) {
+        // When stringified response is too big, we will catch this moment
+        // and throw an error to make sure server is NOT crashed
+        this.emit('end', error);
+      }
     });
 
     incoming.on('error', cleanUp);

--- a/src/lib/connectors/http.js
+++ b/src/lib/connectors/http.js
@@ -197,6 +197,7 @@ HttpConnector.prototype.request = function(params, cb) {
       } catch (error) {
         // When stringified response is too big, we will catch this moment
         // and destroy it to make sure server is NOT crashed
+        response = error.message
         this.destroy(error);
       }
     });


### PR DESCRIPTION
When adding the chunks to stringified response would end up with very big string, the error about it will end up request instead of crashing server.

![image](https://github.com/user-attachments/assets/fee3fe37-a05b-42a0-879b-2cf41f8fda18)

![image](https://github.com/user-attachments/assets/0660531e-b189-4c70-9a36-6b1cd47e5008)


